### PR TITLE
add #include <endian.h> so srtla compiles under musl libc

### DIFF
--- a/common.c
+++ b/common.c
@@ -16,6 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <endian.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>


### PR DESCRIPTION
See https://www.spinics.net/lists/linux-bluetooth/msg45704.html for some context. musl libc is used by alpine linux.